### PR TITLE
Add AttributeError to except ImportError statements

### DIFF
--- a/dissect/etl/manifest.py
+++ b/dissect/etl/manifest.py
@@ -181,7 +181,7 @@ def lookup(guid: UUID) -> types.ModuleType:
         mod = importlib.import_module(f"{MODPATH}.{{{guid}}}")
         CACHE[guid] = mod
         return mod
-    except ImportError:
+    except (AttributeError, ImportError):
         pass
 
     try:


### PR DESCRIPTION
In some cases windows throws an AttributeError instead of an ImportError during an import