### PR TITLE
Fix endianess, decorator and matching manifest event_id issues

### DIFF
--- a/dissect/etl/etl.py
+++ b/dissect/etl/etl.py
@@ -237,7 +237,11 @@ class Event:
         # Not every header has an opcode and version, so check it like this.
         opcode = getattr(header, "opcode", None)
         version = getattr(header, "version", None)
-        key = (opcode, version)
+        try:
+            ide = getattr(header.descriptor, "task", None)
+        except:
+            ide = opcode
+        key = (ide, version)
 
         if event_manifest:
             try:
@@ -276,7 +280,7 @@ class Event:
         The event data is from a specific manifest file if it exists.
         """
         event_values = self._header.additional_header_fields()
-        struct_events = self._struct._values if self._struct else {}
+        struct_events = self._struct.__values__ if self._struct else {}
 
         # Pretty print Instance values.
         update_event = {}

--- a/dissect/etl/headers/event.py
+++ b/dissect/etl/headers/event.py
@@ -217,7 +217,7 @@ class EventHeader(Header):
     @property
     def provider_id(self) -> UUID:
         """Provider that generated this event."""
-        return UUID(bytes=self.header.ProviderId)
+        return UUID(bytes_le=self.header.ProviderId)
 
     @property
     def activity_id(self) -> UUID:

--- a/dissect/etl/manifest.py
+++ b/dissect/etl/manifest.py
@@ -70,6 +70,7 @@ class EtwPointer(VariableType):
         cls.size = 8
         cls.type = cls.cs.uint64
 
+    @classmethod
     def as_32bit(cls):
         if cls.size == 4:
             return


### PR DESCRIPTION
Testing library with etl files throws some errors related with missing
decorator
Library showed many provider_id that not matches with other tools.
It was due to endianess issue
With sample file, there are many entries with unexisting provider_id
d46e3330-27e3-7c44-9de0-51b652c86108
but 30336ed4-e327-447c-9de0-51b652c86108 exists in manifests/xml
folder and matches with other tools

The third problem was getting payload results.
It was related with opcode that sometimes not matches with
manifest event_id. As a result it tries to parse payload with incorrect
manifest event. Code it is not optimal and other header values could be
used instead task

Sample file:
[ExplorerStartupLog_RunOnce.etl.gz](https://github.com/user-attachments/files/24394170/ExplorerStartupLog_RunOnce.etl.gz)


